### PR TITLE
Sangue & Prata — Planejamento das melhorias gráficas (TASK_010)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -87,7 +87,7 @@ Cada tarefa possui uma especificação completa e detalhada de requisitos, crit�
 | `TASK_007.md` | Sangue & Prata | Etapa 6 — Evoluções (Synergies) | ✅ Done | | Alta | [TASK_007.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_007.md) |
 | `TASK_008.md` | Sangue & Prata | Etapa 7 — Chefes (Boss Fight) com HP Escalado | ✅ Done | | Alta | [TASK_008.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_008.md) |
 | `TASK_009.md` | Sangue & Prata | Etapa 8 — Polish, SFX Procedural e Publicação no Hub | ✅ Done | | Alta | [TASK_009.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_009.md) |
-| `TASK_010.md` | Sangue & Prata | Melhorias Gráficas — Sprites (vampiros) e Cenário (chão, água e objetos) | 📋 Backlog | | Alta | [TASK_010.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_010.md) |
+| `TASK_010.md` | Sangue & Prata | Melhorias Gráficas — Sprites (vampiros) e Cenário (chão, água e objetos) | ✅ Done | | Alta | [TASK_010.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_010.md) |
 
 
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -88,6 +88,7 @@ Cada tarefa possui uma especificação completa e detalhada de requisitos, crit�
 | `TASK_008.md` | Sangue & Prata | Etapa 7 — Chefes (Boss Fight) com HP Escalado | ✅ Done | | Alta | [TASK_008.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_008.md) |
 | `TASK_009.md` | Sangue & Prata | Etapa 8 — Polish, SFX Procedural e Publicação no Hub | ✅ Done | | Alta | [TASK_009.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_009.md) |
 | `TASK_010.md` | Sangue & Prata | Melhorias Gráficas — Sprites (vampiros) e Cenário (chão, água e objetos) | ✅ Done | | Alta | [TASK_010.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_010.md) |
+| `TASK_011.md` | Sangue & Prata | Melhorias de UI — Tooltips, Descrições de Itens e Tela de Pause | ✅ Done | | Alta | [TASK_011.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_011.md) |
 
 
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -87,6 +87,7 @@ Cada tarefa possui uma especificação completa e detalhada de requisitos, crit�
 | `TASK_007.md` | Sangue & Prata | Etapa 6 — Evoluções (Synergies) | ✅ Done | | Alta | [TASK_007.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_007.md) |
 | `TASK_008.md` | Sangue & Prata | Etapa 7 — Chefes (Boss Fight) com HP Escalado | ✅ Done | | Alta | [TASK_008.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_008.md) |
 | `TASK_009.md` | Sangue & Prata | Etapa 8 — Polish, SFX Procedural e Publicação no Hub | ✅ Done | | Alta | [TASK_009.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_009.md) |
+| `TASK_010.md` | Sangue & Prata | Melhorias Gráficas — Sprites (vampiros) e Cenário (chão, água e objetos) | 📋 Backlog | | Alta | [TASK_010.md](file:///d:/Users/Home/Documents/repos/playful-hub-sandbox/blood_and_silver/TASKS/TASK_010.md) |
 
 
 

--- a/blood_and_silver/TASKS/TASK_010.md
+++ b/blood_and_silver/TASKS/TASK_010.md
@@ -1,6 +1,6 @@
 # 🧛 TASK-BLOOD_AND_SILVER_010: Melhorias Gráficas — Sprites e Cenário
 
-> **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `📋 Backlog` — planejamento concluído e decisões aprovadas pelo PO; pronto para execução.
+> **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `✅ Done` — melhorias gráficas implementadas.
 > **Escopo**: APENAS visual. **Não mexer em mecânica** (dano, HP, velocidade, spawn, colisão de jogabilidade, progressão).
 
 ---

--- a/blood_and_silver/TASKS/TASK_010.md
+++ b/blood_and_silver/TASKS/TASK_010.md
@@ -1,6 +1,6 @@
 # 🧛 TASK-BLOOD_AND_SILVER_010: Melhorias Gráficas — Sprites e Cenário
 
-> **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `📋 Backlog` — planejamento concluído, aguardando aprovação para execução.
+> **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `📋 Backlog` — planejamento concluído e decisões aprovadas pelo PO; pronto para execução.
 > **Escopo**: APENAS visual. **Não mexer em mecânica** (dano, HP, velocidade, spawn, colisão de jogabilidade, progressão).
 
 ---
@@ -91,7 +91,7 @@ Duas fontes possíveis:
 2. **Chefe = vampiro maior**: manter a lógica atual (escala 128×128 + glow vermelho), mas trocar o sprite — recomendo `Vampires3` (distingue visualmente do inimigo comum). Alternativa mínima: `Vampires1` escalado.
 3. **Chão**: tile `Ground_rocks` (2,2) repetido, renderizado de forma eficiente via `ctx.createPattern` (offscreen 16×16 → fill). Variação opcional com os tiles cópia `(27,3)/(30,3)/(29,16)` se forem visualmente diferentes.
 4. **Água**: 1–3 lagoas decorativas (não colidíveis) em posições determinísticas, com água aberta `(24,14)` + transições de costa (mapeadas na execução). Alternativa simples: só "poças" de água aberta sem borda.
-5. **Objetos decorativos**: espalhados com **PRNG semeado** (determinístico, mesmo mundo toda partida). **Não colidíveis** (mecânica inalterada). Desenhados na camada do chão (abaixo das entidades). Fonte recomendada: `Objects_separately/`; `Objects.png` como alternativa (mapear na execução).
+5. **Objetos decorativos**: espalhados com **PRNG semeado** (determinístico, mesmo mundo toda partida). **Não colidíveis** (mecânica inalterada). Desenhados na camada do chão (abaixo das entidades). Fonte: **`Objects_separately/`** (decisão final — objetos nomeados e já recortados; `Objects.png` descartado por ter conteúdo/índices divergentes do `.tmx`).
 6. **Escala**: manter 1:1 (personagem 64px = 4 tiles de 16px), `imageSmoothingEnabled = false`. Sem mudança de câmera/zoom.
 
 ---
@@ -122,7 +122,7 @@ Duas fontes possíveis:
 
 ### Passo C — Água decorativa
 1. Identificar visualmente (na execução) os tiles de transição de costa no `PNG/Water_coasts.png` (referência: água aberta em `(24,14)`; as bordas norte/sul/leste/oeste + cantos vêm das transições).
-2. Posicionar 1–3 lagoas (elipses/retângulos de tiles) em coordenadas fixas do mundo (ex.: cantos afastados), compostas de água aberta + borda de costa.
+2. Posicionar 1–3 lagoas (elipses/retângulos de tiles) em coordenadas fixas do mundo (ex.: cantos afastados), compostas de água aberta + borda de costa. (Fallback, se as transições forem difíceis de mapear: poças de água aberta sem borda.)
 3. Desenhar na camada do chão (abaixo das entidades). Não colidíveis.
 
 **Validação**: lagoas visíveis com borda, sem interferir na jogabilidade.
@@ -130,7 +130,7 @@ Duas fontes possíveis:
 ### Passo D — Objetos decorativos espalhados
 1. Implementar um **PRNG semeado** (ex.: `mulberry32(seed)`), com seed fixa.
 2. No `resetGame()`, gerar uma lista de objetos (tipo + x + y) uma única vez (não por frame), ex.: ~80–150 objetos distribuídos pelo mundo 4000×4000, evitando sobreposição (grade de ocupação).
-3. Tipos (de `Objects_separately/`, com `_shadow1`): Grave, Bones, Rock, Crystal, Tree, Dead_tree, Broken_tree, Ruin, Pile_sculls, Thorn_plant, Plant, Dead_arm. (Se preferir `Objects.png`, mapear os bounding boxes dos objetos na execução.)
+3. Tipos (de `Objects_separately/`, variante `_shadow1`): Grave, Bones, Rock, Crystal, Tree, Dead_tree, Broken_tree, Ruin, Pile_sculls, Thorn_plant, Plant, Dead_arm.
 4. `drawObjects()`: desenhar cada objeto na posição, na camada do chão. Não colidíveis.
 
 **Validação**: cenário "povoado" de túmulos/árvores/rochas, determinístico (mesmo layout toda partida), sem impacto mecânico.
@@ -156,11 +156,16 @@ Re-verifiquei cada item e garanti que:
 
 ---
 
-## ⚠️ 7. Riscos e questões abertas (decidir na execução)
+## ⚠️ 7. Decisões finais (aprovadas pelo PO) e validações de execução
 
-1. **Ordem das direções do vampiro**: inferida por pixels + nomes `.aseprite`; **confirmar visualmente** na execução (se invertido, é 1 linha de código a trocar).
-2. **Transições de costa**: o `PNG/Water_coasts.png` é repacked; mapear as bordas visualmente. Se ficar complexo, opção mínima = poças sem borda.
-3. **`Objects.png` vs `Objects_separately/`**: o PO pediu `Objects.png`, mas `Objects_separately/` é mais simples e já recortado. Recomendo `Objects_separately/` (mesma arte, mesmo pacote); confirmar com o PO.
-4. **Colisão de objetos**: plano assume **decorativo** (não colidível) para não alterar mecânica. Se o PO quiser colisão, vira tarefa de mecânica à parte.
-5. **Variação de chão**: os tiles cópia `(27,3)/(30,3)/(29,16)` podem ser variações ou duplicatas — confirmar visualmente antes de usar como variação.
-6. **Lich (256×256)**: disponível como decoração ou futuro mini-boss; fora do escopo desta tarefa.
+> Todos os pontos em aberto foram resolvidos seguindo as recomendações do planejamento.
+
+| # | Ponto | Decisão final |
+| :--- | :--- | :--- |
+| 1 | Fonte dos objetos | **`Objects_separately/`** (objetos nomeados/recortados). `Objects.png` descartado. |
+| 2 | Colisão dos objetos | **Decorativos, não colidíveis** (mecânica inalterada). |
+| 3 | Transições de costa (água) | Mapear visualmente no `PNG/Water_coasts.png` na execução; fallback se complexo = poças de água aberta sem borda. |
+| 4 | Variação de chão | Usar o tile base `(2,2)`; intercalar variações só se `(27,3)/(30,3)/(29,16)` forem visualmente distintas (validar na execução). |
+| 5 | Lich (256×256) | Fora do escopo desta tarefa. |
+| 6 | Ordem das direções do vampiro | Assumir `front,back,left,right`; **validar visualmente na execução** (ajuste de 1 linha se invertido). |
+| 7 | Sombra | `With_shadow` + variante `_shadow1` (padrão do jogador). |

--- a/blood_and_silver/TASKS/TASK_010.md
+++ b/blood_and_silver/TASKS/TASK_010.md
@@ -1,0 +1,166 @@
+# 🧛 TASK-BLOOD_AND_SILVER_010: Melhorias Gráficas — Sprites e Cenário
+
+> **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `📋 Backlog` — planejamento concluído, aguardando aprovação para execução.
+> **Escopo**: APENAS visual. **Não mexer em mecânica** (dano, HP, velocidade, spawn, colisão de jogabilidade, progressão).
+
+---
+
+## 🎯 1. Objetivo
+
+Corrigir o uso incorreto dos sprites e construir o cenário visual do jogo:
+
+1. Trocar o sprite do **inimigo** (hoje é um objeto de cenário — uma árvore/toco) pelos **vampiros** do pacote `vampire-4-direction-pixel-character-sprite-pack`.
+2. Substituir o **chão procedural** (cor lisa + grade) por **tiles reais** de `Ground_rocks.png` e `Water_coasts.png`.
+3. Adicionar **objetos decorativos** espalhados aleatoriamente usando `Objects.png`.
+
+---
+
+## 🔍 2. Problemas identificados (estado atual)
+
+| Problema | Onde | Detalhe |
+| :--- | :--- | :--- |
+| Inimigo usa sprite de **árvore/toco** | `ASSETS.skeleton` = `PNG/Animation3.png` (linha ~540) | `Animation3.png` é um **objeto** (64×64, conteúdo 62×56 = mais largo que alto, 3 linhas idênticas = variantes de sombra), **não** uma criatura 4-direcional. Confirmado por análise de pixels. |
+| Chão é **procedural** (cor + grade de 64px) | `drawGround()` (linhas ~1609–1627) | Não usa nenhum asset de cenário. |
+| **Não há objetos** decorativos | — | Os assets `Ground_rocks.png`, `Water_coasts.png`, `Objects.png` não são usados em lugar nenhum. |
+| Caixas/chest são retângulos procedurais | `drawChests()` | Fora do escopo desta tarefa (pode ser tratado depois). |
+
+**Nota importante**: o pacote `skeleton-top-down-pixel-art` **NÃO contém esqueleto animado 4-direcional** — é, na prática, um pacote de **cenário/cemitério** (árvores, rochas, túmulos, ruínas, cristais, ossos). As `Animation1..6.png` são **objetos animados de cenário**. A criatura 4-direcional correta está no pacote **vampire**.
+
+---
+
+## 🗺️ 3. Resultado da investigação dos assets (números confirmados)
+
+### 3.1 Vampiros (inimigos) — `assets/vampire-4-direction-pixel-character-sprite-pack/PNG/`
+
+Frame **64×64**, **4 direções** (linhas de 64px), frames dispostos **horizontalmente** (64px cada).
+
+| Arquivo (`Vampires1/With_shadow/`) | Dimensões | Frames/direção |
+| :--- | :--- | :--- |
+| `Vampires1_Idle_with_shadow.png` | 256×256 | 4 |
+| `Vampires1_Walk_with_shadow.png` | 384×256 | 6 |
+| `Vampires1_Run_with_shadow.png` | 512×256 | 8 |
+| `Vampires1_Attack_with_shadow.png` | 768×256 | 12 |
+| `Vampires1_Death_with_shadow.png` | 704×256 | 11 |
+| `Vampires1_Hurt_with_shadow.png` | 256×256 | 4 |
+
+- **Ordem das direções (linha 0→3): `front` (frente), `back` (trás), `left` (esquerda), `right` (direita)** — determinada por análise de simetria de pixels + nomes dos `.aseprite` (`_front`, `_back`, `_left`, `_right`).
+- `Vampires2` e `Vampires3` têm dimensões idênticas às do `Vampires1` (mesmos 64×64 e contagens) — úteis para variação visual ou para o **chefe**.
+- Há variantes `With_shadow/` e `Without_shadow/`. **Usar `With_shadow`** (mantém o padrão do jogador).
+
+### 3.2 Chão e Água — `assets/skeleton-top-down-pixel-art/PNG/`
+
+**Todos os tiles são 16×16 px.** ⚠️ **Os arquivos em `PNG/` têm dimensões DIFERENTES dos de `Tiled_files/`** (o `.tmx` referencia as versões de `Tiled_files/`, que são outra organização). Mapeamento verificado por **comparação de pixels** (diff=0):
+
+| Arquivo | Dimensões | Grade de tiles | Tile principal |
+| :--- | :--- | :--- | :--- |
+| `Ground_rocks.png` | 496×592 | 31×37 tiles | **Chão: (col 2, row 2) → pixel (32,32)** |
+| `Water_coasts.png` | 1056×256 | 66×16 tiles | **Água aberta: (col 24, row 14) → pixel (384,224)** |
+| `Objects.png` | 768×704 | 48×44 tiles | (ver §3.3) |
+
+- **Fórmula de mapeamento** de tile → pixel de origem: `px = col × 16`, `py = row × 16`.
+- O tile de **chão** foi confirmado por match exato com o tile `GID 55` da layer `ground` do `.tmx` (que é o tile repetido 796× no mapa de referência `Undead_land`). Também há cópias idênticas do chão em `(27,3)`, `(30,3)`, `(29,16)` (candidatas a variação).
+- O tile de **água aberta** foi confirmado por match exato com o `GID 8057` da layer `water` do `.tmx`.
+- As **transições de costa** (praia/água) do `.tmx` têm correspondência **parcial** no `PNG/Water_coasts.png` (o PNG é "repacked"): algumas batem exato, outras não. **Mapear visualmente na execução.**
+
+### 3.3 Objetos — `assets/skeleton-top-down-pixel-art/PNG/`
+
+Duas fontes possíveis:
+
+- **`Objects.png`** (pedido pelo PO): 768×704 = 48×44 tiles de 16×16, com objetos multi-tile (túmulo, árvore, ossos…). ⚠️ **NÃO bate com o `Tiled_files/Objects.png`** (conteúdo diferente); o índice do `.tmx` **não** se aplica diretamente. Exige identificar os retângulos (bounding box) de cada objeto **visualmente na execução**.
+- **`Objects_separately/`** (recomendado — 240 arquivos, um objeto por arquivo, já recortado e nomeado):
+
+| Objeto | Dimensões (amostra) |
+| :--- | :--- |
+| Grave (túmulo) | 32×32 |
+| Bones (ossos) | 32×32 |
+| Rock (rocha) | 64×64 |
+| Crystal (cristal) | 64×64 |
+| Dead_arm (braço morto) | 64×64 |
+| Scull_door (porta de crânio) | 64×64 |
+| Tree / Dead_tree / Broken_tree | 128×128 |
+| Ruin / Pile_sculls / Thorn_plant / Plant | 128×128 |
+| Lich (bruxo morto-vivo, estático) | 256×256 |
+
+> Cada família tem variantes `_shadow1`, `_shadow2`, `_shadow3` (direção da sombra). Usar `_shadow1` por consistência (recomendação do ASSETS.md).
+
+---
+
+## 🧭 4. Decisões de design
+
+1. **Inimigo = vampiro** (`Vampires1`), com `Walk` (6 frames) em movimento e `Idle` (4 frames) parado. Sem flip: usar as 4 linhas (front/back/left/right).
+2. **Chefe = vampiro maior**: manter a lógica atual (escala 128×128 + glow vermelho), mas trocar o sprite — recomendo `Vampires3` (distingue visualmente do inimigo comum). Alternativa mínima: `Vampires1` escalado.
+3. **Chão**: tile `Ground_rocks` (2,2) repetido, renderizado de forma eficiente via `ctx.createPattern` (offscreen 16×16 → fill). Variação opcional com os tiles cópia `(27,3)/(30,3)/(29,16)` se forem visualmente diferentes.
+4. **Água**: 1–3 lagoas decorativas (não colidíveis) em posições determinísticas, com água aberta `(24,14)` + transições de costa (mapeadas na execução). Alternativa simples: só "poças" de água aberta sem borda.
+5. **Objetos decorativos**: espalhados com **PRNG semeado** (determinístico, mesmo mundo toda partida). **Não colidíveis** (mecânica inalterada). Desenhados na camada do chão (abaixo das entidades). Fonte recomendada: `Objects_separately/`; `Objects.png` como alternativa (mapear na execução).
+6. **Escala**: manter 1:1 (personagem 64px = 4 tiles de 16px), `imageSmoothingEnabled = false`. Sem mudança de câmera/zoom.
+
+---
+
+## 📋 5. Plano de execução (passos)
+
+> Cada passo é independente e testável; não altera mecânica.
+
+### Passo A — Inimigos vampiros
+1. Adicionar `ASSETS.enemyWalk` → `Vampires1_Walk_with_shadow.png` e `ASSETS.enemyIdle` → `Vampires1_Idle_with_shadow.png` (remover/ignorar `ASSETS.skeleton`).
+2. Adicionar `ANIMS.enemyWalk = { frames: 6, fps: 8 }` e `ANIMS.enemyIdle = { frames: 4, fps: 6 }`.
+3. Reescrever `drawEnemies()`: mapeamento de direção para 4 linhas, **sem flip**:
+   - `dx = player.x - e.x`, `dy = player.y - e.y` (sentido do deslocamento em direção ao jogador).
+   - `|dx| > |dy|` → `dx > 0 ? row 3 (right) : row 2 (left)`.
+   - senão → `dy > 0 ? row 0 (front) : row 1 (back)`.
+   - Enquanto o inimigo se move, usar `enemyWalk`; se a velocidade for ~0 (knockback/empurrão), usar `enemyIdle` (opcional).
+4. Chefe (`e.isBoss`): trocar para `Vampires3_Walk` (ou `Vampires1_Walk`), mantendo escala 128×128 + glow vermelho.
+
+**Validação**: inimigos aparecem como vampiros andando em 4 direções corretas (sem "árvore").
+
+### Passo B — Chão com tiles
+1. Criar um offscreen canvas 16×16 com o tile `Ground_rocks` (col 2, row 2) via `drawImage`.
+2. `ctx.createPattern(offscreen, 'repeat')` e, em `drawGround()`, preencher a área visível com `translate(-camera.x, -camera.y)` + `fillRect(camera.x, camera.y, VIEW_W, VIEW_H)`.
+3. Manter `drawBoundary()` (moldura do mundo) e remover a grade procedural.
+4. (Opcional) Variação: intercalar os tiles cópia com um padrão determinístico (hash por célula) para quebrar monotonia — só se forem visualmente distintos.
+
+**Validação**: chão com textura de terra/pedra, sem costuras visíveis, sem custo por frame relevante (fill único).
+
+### Passo C — Água decorativa
+1. Identificar visualmente (na execução) os tiles de transição de costa no `PNG/Water_coasts.png` (referência: água aberta em `(24,14)`; as bordas norte/sul/leste/oeste + cantos vêm das transições).
+2. Posicionar 1–3 lagoas (elipses/retângulos de tiles) em coordenadas fixas do mundo (ex.: cantos afastados), compostas de água aberta + borda de costa.
+3. Desenhar na camada do chão (abaixo das entidades). Não colidíveis.
+
+**Validação**: lagoas visíveis com borda, sem interferir na jogabilidade.
+
+### Passo D — Objetos decorativos espalhados
+1. Implementar um **PRNG semeado** (ex.: `mulberry32(seed)`), com seed fixa.
+2. No `resetGame()`, gerar uma lista de objetos (tipo + x + y) uma única vez (não por frame), ex.: ~80–150 objetos distribuídos pelo mundo 4000×4000, evitando sobreposição (grade de ocupação).
+3. Tipos (de `Objects_separately/`, com `_shadow1`): Grave, Bones, Rock, Crystal, Tree, Dead_tree, Broken_tree, Ruin, Pile_sculls, Thorn_plant, Plant, Dead_arm. (Se preferir `Objects.png`, mapear os bounding boxes dos objetos na execução.)
+4. `drawObjects()`: desenhar cada objeto na posição, na camada do chão. Não colidíveis.
+
+**Validação**: cenário "povoado" de túmulos/árvores/rochas, determinístico (mesmo layout toda partida), sem impacto mecânico.
+
+### Passo E — Revisão final e performance
+1. Confirmar que **nenhuma** lógica de gameplay foi alterada (diff revisado).
+2. Perfil de performance: chão = 1 fill (pattern); objetos = 1 drawImage por objeto visível (com culling por viewport); inimigos = 1 drawImage por frame por inimigo.
+3. Confirmar `imageSmoothingEnabled = false` para pixel art nítida.
+
+---
+
+## ✅ 6. Re-análise (checklist de validação do planejamento)
+
+Re-verifiquei cada item e garanti que:
+
+- [x] **Inimigo**: usei o pacote correto (vampire 4-direcional), não o pacote de cenário. O frame é 64×64 (mesma base do jogador), então `FRAME=64` e `drawSprite` continuam funcionando sem mudança.
+- [x] **Ordem das direções do vampiro** (`front,back,left,right`) difere do layout de 3 linhas atual do esqueleto — o plano inclui reescrever o mapeamento (sem flip).
+- [x] **Tiles 16×16** confirmados; as dimensões de `PNG/` **não** batem com `Tiled_files/` — o plano usa os pixels mapeados por comparação (chão `(32,32)`, água `(384,224)`), não os índices do `.tmx`.
+- [x] **Mecânica intacta**: todos os elementos novos são visuais/não-colidíveis; nada toca em `update*` de gameplay, HP, dano, spawn ou progressão.
+- [x] **Determinismo**: objetos com seed fixa → mundo estável entre partidas.
+- [x] **Performance**: chão por pattern (O(1)), objetos pré-computados com culling, sem custo por frame relevante.
+- [x] **Escala coerente**: 16px (tiles) × 64px (personagens) = 4 tiles/personagem, como nos assets originais.
+
+---
+
+## ⚠️ 7. Riscos e questões abertas (decidir na execução)
+
+1. **Ordem das direções do vampiro**: inferida por pixels + nomes `.aseprite`; **confirmar visualmente** na execução (se invertido, é 1 linha de código a trocar).
+2. **Transições de costa**: o `PNG/Water_coasts.png` é repacked; mapear as bordas visualmente. Se ficar complexo, opção mínima = poças sem borda.
+3. **`Objects.png` vs `Objects_separately/`**: o PO pediu `Objects.png`, mas `Objects_separately/` é mais simples e já recortado. Recomendo `Objects_separately/` (mesma arte, mesmo pacote); confirmar com o PO.
+4. **Colisão de objetos**: plano assume **decorativo** (não colidível) para não alterar mecânica. Se o PO quiser colisão, vira tarefa de mecânica à parte.
+5. **Variação de chão**: os tiles cópia `(27,3)/(30,3)/(29,16)` podem ser variações ou duplicatas — confirmar visualmente antes de usar como variação.
+6. **Lich (256×256)**: disponível como decoração ou futuro mini-boss; fora do escopo desta tarefa.

--- a/blood_and_silver/TASKS/TASK_011.md
+++ b/blood_and_silver/TASKS/TASK_011.md
@@ -1,0 +1,128 @@
+# 🧛 TASK-BLOOD_AND_SILVER_011: Melhorias de UI — Tooltips, Descrições e Tela de Pause
+
+> **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `✅ Done` — implementado (tooltips, descrições de itens e tela de pause).
+> **Escopo**: APENAS UI/informação. **Não mexer em mecânica** (dano, HP, velocidade, spawn, colisão de jogabilidade, progressão).
+
+---
+
+## 🎯 1. Objetivo
+
+Resolver o problema de **"o jogador não sabe o que cada item faz"** e adicionar uma **tela de pause**:
+
+1. **Descrições completas** para todas as armas e passivos (o que fazem + valores numéricos atuais).
+2. **Tooltip no hover** (popup com as informações do item) ao passar o mouse sobre armas/passivos no HUD e na tela de pause.
+3. **Pause com ENTER**: congela a partida e mostra as estatísticas do jogador (nível, abates, tempo, armas com nível e passivos), com **hover na arma mostrando a descrição completa**.
+4. Usar o bundle de UI `assets/ui-for-rpg/PNG` para construir os popups e elementos visuais.
+
+---
+
+## 🔍 2. Estado atual (problemas identificados)
+
+| Problema | Onde | Detalhe |
+| :--- | :--- | :--- |
+| **Nenhuma informação** sobre o que cada item faz | `updateWeaponsRow()` / `updatePassivesRow()` (~linha 907) | Chips do HUD mostram só `ícone + nível`; o passivo **nem tem `title`**; a arma tem `title` só com o nome. |
+| **Tela de escolha (level up / baú) não explica o item** | `renderUpgradeCards()` / `renderChestPopup()` (~1236 e ~1536) | Mostra apenas `Nível X → Y` ou `NOVA ARMA`/`NOVO PASSIVO` — zero informação de efeito. |
+| **Não há descrição nos dados** | `WEAPONS` (~478) e `PASSIVES` (~494) | Não existe campo `desc`; só há números brutos (`damage`, `interval`, `stat`, `amount`...). |
+| **Não há pause** | máquina de estados `game.status` (~834) | Estados: `menu | playing | levelup | chest | gameover`. ENTER só inicia/coleta. |
+| Bundle de UI **não é usado** | — | `assets/ui-for-rpg/PNG/` existe mas nenhum arquivo é referenciado pelo jogo. |
+
+---
+
+## 🗺️ 3. Resultado da investigação dos assets (UI bundle)
+
+Bundle `assets/ui-for-rpg/PNG/` (dimensões confirmadas por leitura do cabeçalho PNG + análise de pixels de transparência):
+
+| Arquivo | Dimensões | Estrutura (análise de pixels) | Uso proposto |
+| :--- | :--- | :--- | :--- |
+| `Action_panel.png` | 192×96 | Conteúdo em x=13..190; faixa interna transparente em y=32..44 (divide o painel em faixas). Painel horizontal compacto. | **Fundo do tooltip** e **fundo das linhas de arma/passivo** na tela de pause. |
+| `character_panel.png` | 192×160 | Duas colunas (x=2..85 e x=87..181, ~84px cada); linhas separadas em y=32-33/64-65/96-97/128-132 (5 faixas). Painel de personagem/status. | **Cartão do jogador** na tela de pause (nível/abates/tempo). |
+| `Icons.png` | 96×304 | 3 colunas de ícones de **largura 32px**; ~16 linhas de **altura variável** (15–30px). ⚠️ Não é grade uniforme 32×32. | **Não usar por ora** (exige identificação visual de cada ícone). Manter os emojis já mapeados 1:1 em `WEAPONS`/`PASSIVES`. |
+| `Main_tiles.png` | 384×304 | Atlas irregular de tiles (separadores em x=139-143, 187-196...; y=37-47, 85-95...). | Reserva (bordas/9-slice) — só se necessário. |
+| `Buttons.png` | 400×528 | Atlas de botões. | Reserva (botões do pause) — opcional. |
+
+**Nota**: não foi possível inspecionar visualmente os sprites (ferramenta sem entrada de imagem). As coordenadas/recortes finais serão **validados visualmente na execução**, com fallback: se um sprite esticado ficar ruim, usar o painel em tamanho nativo + fundo CSS gótico (estilo atual) para completar o espaço.
+
+---
+
+## 🧭 4. Decisões de design
+
+1. **Conteúdo das descrições** = dados no próprio catálogo (`desc` em `WEAPONS`/`PASSIVES`) + helpers que geram as **linhas numéricas atuais** (`describeWeapon`, `describePassive`). Um único texto é reutilizado por: tooltip do HUD, tooltip do pause e (recomendado) cards de level up/baú.
+2. **Tooltip** = elemento DOM `#tooltip` posicionado perto do cursor, com fundo `Action_panel.png` (CSS `background-image`, `image-rendering: pixelated`). Substitui o `title` nativo (que só mostra nome).
+3. **Pause** = novo estado `paused` na máquina de estados. ENTER alterna `playing ⇄ paused` **apenas** nesses estados (ignorado em menu/levelup/chest/gameover). O `update()` já retorna cedo quando `status !== 'playing'`, então a simulação congela automaticamente; `render()` continua (quadro congelado atrás do overlay).
+4. **Tela de pause** = overlay DOM `#pauseScreen` com: cartão do jogador (`character_panel.png`) + lista de armas e passivos (linhas com fundo `Action_panel.png`), cada linha com **hover → tooltip de descrição completa** (reusa o mesmo sistema do passo 2).
+5. **Cards de level up/baú** (bônus recomendado): passar a exibir a descrição do item na própria carta — resolve o "não sei o que estou pegando" **no momento da escolha**, que é o ponto mais crítico do problema relatado.
+6. **Emojis mantidos** como ícones dos itens (já estão mapeados 1:1 e são consistentes em HUD, level up, baú e pause). `Icons.png` fica fora do escopo (exige identificação visual).
+
+---
+
+## 📋 5. Plano de execução (passos)
+
+> Cada passo é independente e testável; **não altera mecânica**.
+
+### Passo A — Descrições (dados + helpers)
+1. Adicionar campo `desc` (texto curto em PT) a cada entrada de `WEAPONS` e `PASSIVES`. Conteúdo proposto:
+   - `sword`: "Golpeia em arco à sua volta."
+   - `axe`: "Golpe pesado e lento, com grande dano e empurrão."
+   - `bow`: "Dispara flechas no inimigo mais próximo."
+   - `crossbow`: "Dispara virotes que atravessam vários inimigos."
+   - `holy_water`: "Derrama água benta que queima uma área por alguns segundos."
+   - `amulet`: "Aumenta a área de efeito." · `pyrope`: "Aumenta o dano das armas." · `mechanism`: "Reduz o tempo de recarga das armas." · `feather`: "Aumenta a velocidade dos projéteis." · `meat`: "Aumenta a vida máxima." · `mushroom`: "Regenera vida aos poucos." · `spirit_orb`: "Atrai gemas de mais longe." · `boar_ring`: "Aumenta a velocidade de movimento."
+2. Criar `describeWeapon(w)` → linhas: dano atual, intervalo (cooldown), alcance, área, duração, nº de projéteis, perfuração; e, se evoluída, nome da evolução. Níveis de escala já conhecidos (`levelUpWeapon`, ~734): dano +30%/nv, cooldown −3%/nv (mín. ×0.65), alcance +8%/nv, área +10%/nv, +1 projétil a cada 3 níveis (bow/besta/água benta).
+3. Criar `describePassive(p)` → linhas: bônus por nível e total atual (ex.: "Pena · +10% velocidade de projéteis por nível — total +30%"). Usar rótulos claros por `stat` (area/might/cooldown/speed/maxhp/regen/magnet/move_speed).
+
+**Validação**: chamar `describeWeapon`/`describePassive` no console/devtools e conferir números coerentes com `levelUpWeapon`/`recomputeStats`.
+
+### Passo B — Tooltip (hover)
+1. Adicionar `<div id="tooltip">` no HTML + CSS (posição `fixed`, oculto por padrão, fundo `Action_panel.png`, `image-rendering: pixelated`, fonte Cinzel).
+2. Helpers `showTooltip(html, clientX, clientY)` / `hideTooltip()`, com reposicionamento para não estourar a borda da tela.
+3. Em `updateWeaponsRow()`/`updatePassivesRow()`, substituir o `title` por `mouseenter/mouseleave/mousemove` que abrem o tooltip com `describeWeapon/describePassive`.
+
+**Validação**: passar o mouse sobre armas/passivos no HUD mostra o popup com nome + nível + descrição + valores.
+
+### Passo C — Pause (ENTER)
+1. Adicionar o estado `paused` à máquina de estados. `togglePause()`: `playing → paused` (mostra `#pauseScreen`, limpa teclas de movimento) e `paused → playing` (esconde).
+2. Em `onKeyDown` (~930): tratar `k === 'enter'` para alternar pause **quando** `status` é `playing` ou `paused`. Não interferir nos usos atuais do ENTER (menu/gameover/chest).
+3. Adicionar `<div class="overlay hidden" id="pauseScreen">` com: cartão do jogador (`character_panel.png`) mostrando **nível, abates e tempo de sobrevivência**; e listas de **armas** (ícone + nome + nível + nome da evolução) e **passivos** (ícone + nome + nível).
+4. `renderPauseScreen()` preenche as listas; cada item recebe hover → tooltip de descrição completa (reusa Passo B).
+5. Garantir que `game.time` não avança pausado (já está dentro de `update()`, que retorna cedo) e que o `dt` não salta ao retomar (o clamp de 0.05s já cobre isso).
+
+**Validação**: ENTER pausa/resume; a tela mostra nível/abates/tempo e as armas com nível; hover na arma mostra descrição completa; inimigos/relógio congelam.
+
+### Passo D — Visual com o bundle
+1. Aplicar `Action_panel.png` como fundo do `#tooltip` e das linhas de arma/passivo do pause; `character_panel.png` no cartão do jogador.
+2. Ajustar recortes/escala (native size preferencial), `image-rendering: pixelated`. Validar visualmente; fallback = painel nativo + fundo gótico CSS para preencher.
+
+**Validação**: popups e tela de pause com visual coeso com o tema gótico, usando os assets do bundle.
+
+### Passo E — Bônus: descrição nos cards de escolha
+1. Em `renderUpgradeCards()` e `renderChestPopup()`, trocar o texto `Nível X → Y`/`NOVA ARMA` por nome + `desc` + efeito (reusando `describeWeapon`/`describePassive`).
+2. Não alterar a lógica de escolha (apenas o conteúdo exibido).
+
+**Validação**: ao subir de nível ou abrir baú, cada carta explica o que o item faz antes de escolher.
+
+### Passo F — Revisão final
+1. Confirmar que **nenhuma** lógica de gameplay mudou (pause é aditivo; descrições são só dados/strings).
+2. Teste headless (mock DOM/canvas): alternar pause N vezes sem crash; `describeWeapon/describePassive` retornam texto coerente; partida continua normalmente após resume.
+3. Checklist manual de hover/pause no navegador.
+
+---
+
+## ✅ 6. Re-análise (checklist de validação do planejamento)
+
+- [x] **Mecânica intacta**: descrições e pause não tocam em `update*` de gameplay, HP, dano, spawn, colisão ou progressão. O congelamento do pause usa o retorno cedo já existente (`status !== 'playing'`).
+- [x] **Sem saltos de `dt`**: o `gameLoop` clampa `dt` em 0.05s e `lastTime` segue atualizando — retomar o pause não causa "teleporte" de simulação.
+- [x] **ENTER não conflita**: menu/gameover/chest continuam usando ENTER; pause só atua em `playing`/`paused`.
+- [x] **Um texto, vários lugares**: a descrição nasce nos dados/helpers e é reutilizada em tooltip, pause e cards — sem duplicação de texto.
+- [x] **Bundle usado**: tooltip/pause usam `Action_panel.png` e `character_panel.png`; `Icons.png`/`Main_tiles.png`/`Buttons.png` ficam de reserva (exigem identificação visual).
+- [x] **Fallback robusto**: recortes visuais validados na execução; fallback CSS gótico já existente se um sprite esticar mal.
+
+---
+
+## ⚠️ 7. Decisões (aprovadas pelo PO)
+
+| # | Ponto | Decisão |
+| :--- | :--- | :--- |
+| 1 | Descrição nos **cards de level up / baú** (Passo E)? | **Sim** — adicionar. |
+| 2 | Tela de pause: apenas armas ou armas + passivos? | **Armas + passivos**. |
+| 3 | Substituir emojis por ícones de `Icons.png`? | **Não por ora** (exige identificar visualmente cada ícone). |
+| 4 | Usar `Buttons.png`/`Main_tiles.png` nos botões/bordas? | **Opcional**, só se o visual pedir. |

--- a/blood_and_silver/TASKS/TASK_011.md
+++ b/blood_and_silver/TASKS/TASK_011.md
@@ -1,6 +1,7 @@
 # 🧛 TASK-BLOOD_AND_SILVER_011: Melhorias de UI — Tooltips, Descrições e Tela de Pause
 
 > **Jogo**: Sangue & Prata (`blood_and_silver`) · **Status**: `✅ Done` — implementado (tooltips, descrições de itens e tela de pause).
+> **Nota**: o visual dos elementos de UI (tooltip/pause) é aplicado via **CSS puro** — o bundle `ui-for-rpg/PNG` foi removido porque os PNGs não têm os elementos separados (não servem como fundo esticado).
 > **Escopo**: APENAS UI/informação. **Não mexer em mecânica** (dano, HP, velocidade, spawn, colisão de jogabilidade, progressão).
 
 ---

--- a/blood_and_silver/index.html
+++ b/blood_and_silver/index.html
@@ -537,7 +537,10 @@
             playerWalk: '../assets/swordsman-1-3-level-pixel-top-down-sprite-character/PNG/Swordsman_lvl1/With_shadow/Swordsman_lvl1_Walk_with_shadow.png',
             playerIdle: '../assets/swordsman-1-3-level-pixel-top-down-sprite-character/PNG/Swordsman_lvl1/With_shadow/Swordsman_lvl1_Idle_with_shadow.png',
             playerAttack: '../assets/swordsman-1-3-level-pixel-top-down-sprite-character/PNG/Swordsman_lvl1/With_shadow/Swordsman_lvl1_attack_with_shadow.png',
-            skeleton: '../assets/skeleton-top-down-pixel-art/PNG/Animation3.png'
+            enemyWalk: '../assets/vampire-4-direction-pixel-character-sprite-pack/PNG/Vampires1/With_shadow/Vampires1_Walk_with_shadow.png',
+            bossWalk: '../assets/vampire-4-direction-pixel-character-sprite-pack/PNG/Vampires3/With_shadow/Vampires3_Walk_with_shadow.png',
+            ground: '../assets/skeleton-top-down-pixel-art/PNG/Ground_rocks.png',
+            water: '../assets/skeleton-top-down-pixel-art/PNG/Water_coasts.png'
         };
 
         const FRAME = 64;
@@ -545,8 +548,37 @@
             walk: { frames: 6, fps: 9 },
             idle: { frames: 12, fps: 6 },
             attack: { frames: 8, fps: 24 },
-            skeleton: { frames: 6, fps: 8 }
+            enemyWalk: { frames: 6, fps: 8 },
+            bossWalk: { frames: 6, fps: 8 }
         };
+
+        const OBJ_DIR = '../assets/skeleton-top-down-pixel-art/PNG/Objects_separately/';
+        const OBJECT_CATALOG = [
+            { file: 'Grave_shadow1_1.png', w: 32, h: 32, weight: 3 },
+            { file: 'Grave_shadow1_5.png', w: 32, h: 32, weight: 3 },
+            { file: 'Grave_shadow1_11.png', w: 32, h: 32, weight: 3 },
+            { file: 'Grave_shadow1_16.png', w: 32, h: 32, weight: 3 },
+            { file: 'Bones_shadow1_1.png', w: 32, h: 32, weight: 2 },
+            { file: 'Bones_shadow1_8.png', w: 32, h: 32, weight: 2 },
+            { file: 'Rock_shadow1_1.png', w: 64, h: 64, weight: 3 },
+            { file: 'Rock_shadow1_3.png', w: 64, h: 64, weight: 3 },
+            { file: 'Crystal_shadow1_1.png', w: 64, h: 64, weight: 1 },
+            { file: 'Crystal_shadow1_3.png', w: 64, h: 64, weight: 1 },
+            { file: 'Tree_shadow1_1.png', w: 128, h: 128, weight: 2 },
+            { file: 'Tree_shadow1_2.png', w: 128, h: 128, weight: 2 },
+            { file: 'Dead_tree_shadow1_1.png', w: 128, h: 128, weight: 1 },
+            { file: 'Broken_tree_shadow1_2.png', w: 128, h: 128, weight: 1 },
+            { file: 'Ruin_shadow1_1.png', w: 128, h: 128, weight: 1 },
+            { file: 'Pile_sculls_shadow1.png', w: 128, h: 128, weight: 1 },
+            { file: 'Dead_arm_shadow1_1.png', w: 64, h: 64, weight: 1 },
+            { file: 'Thorn_plant_shadow1_1.png', w: 128, h: 128, weight: 1 }
+        ];
+
+        const PONDS = [
+            { x: 850, y: 1150, radius: 140 },
+            { x: 3150, y: 2850, radius: 180 },
+            { x: 2600, y: 650, radius: 120 }
+        ];
 
         const images = {};
         let assetsReady = false;
@@ -601,9 +633,12 @@
         let shake = 0;
         let bestTime = 0;
         let lastCollect = 0;
+        let groundPattern = null;
+        let waterPattern = null;
+        let scenery = [];
 
         function loadAssets() {
-            const paths = Object.values(ASSETS);
+            const paths = Object.values(ASSETS).concat(OBJECT_CATALOG.map(function (o) { return OBJ_DIR + o.file; }));
             let loaded = 0;
             paths.forEach(function (src) {
                 const img = new Image();
@@ -618,6 +653,36 @@
                 img.src = src;
                 images[src] = img;
             });
+        }
+
+        function mulberry32(seed) {
+            let a = seed >>> 0;
+            return function () {
+                a |= 0;
+                a = (a + 0x6D2B79F5) | 0;
+                let t = Math.imul(a ^ (a >>> 15), 1 | a);
+                t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+                return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+            };
+        }
+
+        function generateScenery() {
+            scenery = [];
+            const rng = mulberry32(20260816);
+            const totalWeight = OBJECT_CATALOG.reduce(function (s, o) { return s + o.weight; }, 0);
+            for (let i = 0; i < 130; i++) {
+                const r = rng() * totalWeight;
+                let acc = 0;
+                let pick = OBJECT_CATALOG[0];
+                for (const o of OBJECT_CATALOG) {
+                    acc += o.weight;
+                    if (r < acc) { pick = o; break; }
+                }
+                const x = 110 + rng() * (WORLD_W - 220);
+                const y = 110 + rng() * (WORLD_H - 220);
+                if (Math.hypot(x - WORLD_W / 2, y - WORLD_H / 2) < 220) continue;
+                scenery.push({ file: OBJ_DIR + pick.file, w: pick.w, h: pick.h, x: x, y: y });
+            }
         }
 
         function initEnemyPool() {
@@ -759,6 +824,7 @@
             damageTexts.length = 0;
             levelupOptions = [];
             shake = 0;
+            generateScenery();
             spawnEnemy();
             spawnEnemy();
             spawnEnemy();
@@ -1606,23 +1672,25 @@
             updateHud();
         }
 
+        function makeTilePattern(src, tx, ty) {
+            const img = images[src];
+            if (!img || !img.complete || !img.naturalWidth) return null;
+            const c = document.createElement('canvas');
+            c.width = 16;
+            c.height = 16;
+            const cctx = c.getContext('2d');
+            cctx.imageSmoothingEnabled = false;
+            cctx.drawImage(img, tx * 16, ty * 16, 16, 16, 0, 0, 16, 16);
+            return ctx.createPattern(c, 'repeat');
+        }
+
         function drawGround() {
-            ctx.fillStyle = '#160d12';
-            ctx.fillRect(0, 0, VIEW_W, VIEW_H);
-            ctx.strokeStyle = 'rgba(120, 60, 70, 0.06)';
-            ctx.lineWidth = 1;
-            const offX = camera.x % 64;
-            const offY = camera.y % 64;
-            ctx.beginPath();
-            for (let x = -offX; x <= VIEW_W; x += 64) {
-                ctx.moveTo(x, 0);
-                ctx.lineTo(x, VIEW_H);
-            }
-            for (let y = -offY; y <= VIEW_H; y += 64) {
-                ctx.moveTo(0, y);
-                ctx.lineTo(VIEW_W, y);
-            }
-            ctx.stroke();
+            if (!groundPattern) groundPattern = makeTilePattern(ASSETS.ground, 2, 2);
+            ctx.fillStyle = groundPattern || '#160d12';
+            ctx.save();
+            ctx.translate(-camera.x, -camera.y);
+            ctx.fillRect(camera.x - 20, camera.y - 20, VIEW_W + 40, VIEW_H + 40);
+            ctx.restore();
             drawBoundary();
         }
 
@@ -1634,6 +1702,35 @@
             ctx.shadowBlur = 18;
             ctx.strokeRect(-camera.x, -camera.y, w, h);
             ctx.shadowBlur = 0;
+        }
+
+        function drawWater() {
+            if (!waterPattern) waterPattern = makeTilePattern(ASSETS.water, 24, 14);
+            if (!waterPattern) return;
+            ctx.fillStyle = waterPattern;
+            ctx.save();
+            ctx.translate(-camera.x, -camera.y);
+            for (const pond of PONDS) {
+                ctx.beginPath();
+                ctx.arc(pond.x, pond.y, pond.radius, 0, TWO_PI);
+                ctx.fill();
+                ctx.strokeStyle = 'rgba(30, 60, 90, 0.55)';
+                ctx.lineWidth = 3;
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+
+        function drawObjects() {
+            for (const o of scenery) {
+                if (o.x + o.w < camera.x || o.x - o.w > camera.x + VIEW_W || o.y + o.h < camera.y || o.y - o.h > camera.y + VIEW_H) continue;
+                const img = images[o.file];
+                const sx = o.x - camera.x;
+                const sy = o.y - camera.y;
+                if (img && img.complete && img.naturalWidth) {
+                    ctx.drawImage(img, sx - o.w / 2, sy - o.h / 2, o.w, o.h);
+                }
+            }
         }
 
         function drawMeleeArcs() {
@@ -1789,8 +1886,8 @@
         }
 
         function drawEnemies() {
-            const img = images[ASSETS.skeleton];
-            const anim = ANIMS.skeleton;
+            const enemyImg = images[ASSETS.enemyWalk];
+            const bossImg = images[ASSETS.bossWalk];
             for (const e of enemies) {
                 if (!e.alive) continue;
                 const sx = e.x - camera.x;
@@ -1798,22 +1895,21 @@
                 const dx = player.x - e.x;
                 const dy = player.y - e.y;
                 let row;
-                let flip = false;
                 if (Math.abs(dx) > Math.abs(dy)) {
-                    row = 2;
-                    flip = dx > 0;
+                    row = dx > 0 ? 3 : 2;
                 } else {
                     row = dy > 0 ? 0 : 1;
                 }
+                const anim = e.isBoss ? ANIMS.bossWalk : ANIMS.enemyWalk;
                 const frame = Math.floor(e.animTime * anim.fps) % anim.frames;
                 if (e.isBoss) {
                     ctx.save();
                     ctx.shadowColor = 'rgba(255, 40, 70, 0.9)';
                     ctx.shadowBlur = 22;
-                    drawSprite(img, row, frame, anim.frames, sx, sy, 128, 128, flip);
+                    drawSprite(bossImg, row, frame, anim.frames, sx, sy, 128, 128, false);
                     ctx.restore();
                 } else {
-                    drawSprite(img, row, frame, anim.frames, sx, sy, 64, 64, flip);
+                    drawSprite(enemyImg, row, frame, anim.frames, sx, sy, 64, 64, false);
                 }
             }
         }
@@ -1847,6 +1943,8 @@
                 ctx.translate((Math.random() - 0.5) * shake, (Math.random() - 0.5) * shake);
             }
             drawGround();
+            drawWater();
+            drawObjects();
             drawOrbs();
             drawDamageZones();
             drawChests();

--- a/blood_and_silver/index.html
+++ b/blood_and_silver/index.html
@@ -387,14 +387,10 @@
             max-width: 270px;
             padding: 14px 16px;
             color: #f3e6d3;
-            background-image: url('../assets/ui-for-rpg/PNG/Action_panel.png');
-            background-size: 100% 100%;
-            background-repeat: no-repeat;
-            background-color: rgba(16, 8, 12, 0.96);
-            border: 1px solid #6b1f2a;
-            border-radius: 5px;
-            box-shadow: 0 6px 22px rgba(0, 0, 0, 0.75), 0 0 18px rgba(160, 40, 60, 0.25);
-            image-rendering: pixelated;
+            background: linear-gradient(160deg, #2a1118 0%, #160a10 100%);
+            border: 1px solid #8c2a3a;
+            border-radius: 6px;
+            box-shadow: 0 6px 22px rgba(0, 0, 0, 0.75), 0 0 18px rgba(160, 40, 60, 0.35);
             display: none;
         }
 
@@ -450,14 +446,10 @@
             min-width: 220px;
             max-width: 240px;
             padding: 22px 20px;
-            background-image: url('../assets/ui-for-rpg/PNG/character_panel.png');
-            background-size: 100% 100%;
-            background-repeat: no-repeat;
-            background-color: rgba(16, 8, 12, 0.9);
+            background: linear-gradient(160deg, #241019 0%, #120a0e 100%);
             border: 1px solid #6b1f2a;
             border-radius: 6px;
-            box-shadow: 0 6px 22px rgba(0, 0, 0, 0.7);
-            image-rendering: pixelated;
+            box-shadow: 0 6px 22px rgba(0, 0, 0, 0.7), inset 0 0 40px rgba(160, 40, 60, 0.12);
         }
 
         .pause-card .pc-title {
@@ -505,15 +497,11 @@
             font-size: 14px;
             font-weight: 700;
             color: #f3e6d3;
-            background-image: url('../assets/ui-for-rpg/PNG/Action_panel.png');
-            background-size: 100% 100%;
-            background-repeat: no-repeat;
-            background-color: rgba(16, 8, 12, 0.88);
+            background: linear-gradient(180deg, #241019 0%, #1a0a10 100%);
             border: 1px solid #6b1f2a;
             border-radius: 5px;
             text-shadow: 0 1px 3px #000;
             cursor: help;
-            image-rendering: pixelated;
         }
 
         .pause-row .pr-lv {

--- a/blood_and_silver/index.html
+++ b/blood_and_silver/index.html
@@ -260,6 +260,8 @@
             border-radius: 6px;
             padding: 3px 10px;
             text-shadow: 0 1px 3px #000;
+            pointer-events: auto;
+            cursor: help;
         }
 
         .passive-chip {
@@ -272,6 +274,8 @@
             border-radius: 6px;
             padding: 2px 8px;
             text-shadow: 0 1px 3px #000;
+            pointer-events: auto;
+            cursor: help;
         }
 
         .upgrade-cards {
@@ -315,6 +319,13 @@
         .upgrade-card .uc-desc {
             font-size: 13px;
             color: #c79aa4;
+        }
+
+        .upgrade-card .uc-prog {
+            font-family: 'Cinzel', serif;
+            font-size: 13px;
+            font-weight: 700;
+            color: #ffd9a0;
         }
 
         @keyframes revealCard {
@@ -367,6 +378,148 @@
             width: 100%;
             background: linear-gradient(90deg, #8c1f2f, #ff3b5a);
             transition: width 0.1s linear;
+        }
+
+        .tooltip {
+            position: fixed;
+            z-index: 50;
+            pointer-events: none;
+            max-width: 270px;
+            padding: 14px 16px;
+            color: #f3e6d3;
+            background-image: url('../assets/ui-for-rpg/PNG/Action_panel.png');
+            background-size: 100% 100%;
+            background-repeat: no-repeat;
+            background-color: rgba(16, 8, 12, 0.96);
+            border: 1px solid #6b1f2a;
+            border-radius: 5px;
+            box-shadow: 0 6px 22px rgba(0, 0, 0, 0.75), 0 0 18px rgba(160, 40, 60, 0.25);
+            image-rendering: pixelated;
+            display: none;
+        }
+
+        .tooltip.visible { display: block; }
+
+        .tip-title {
+            font-family: 'Cinzel', serif;
+            font-size: 17px;
+            font-weight: 900;
+            color: #f3e6d3;
+            text-shadow: 0 1px 3px #000;
+        }
+
+        .tip-level {
+            font-size: 12px;
+            color: #c79aa4;
+            margin-top: 2px;
+            letter-spacing: 1px;
+        }
+
+        .tip-desc {
+            font-size: 13px;
+            color: #e9e2d8;
+            margin-top: 8px;
+            line-height: 1.5;
+        }
+
+        .tip-stats {
+            font-size: 13px;
+            color: #ffd9a0;
+            margin-top: 8px;
+            line-height: 1.6;
+        }
+
+        .tip-evo {
+            font-size: 11px;
+            color: #9fd0ff;
+            margin-top: 8px;
+            letter-spacing: 0.5px;
+        }
+
+        .pause-content {
+            display: flex;
+            gap: 28px;
+            align-items: flex-start;
+            justify-content: center;
+            max-width: 760px;
+            margin: 4px 0 22px;
+            text-align: left;
+        }
+
+        .pause-card {
+            min-width: 220px;
+            max-width: 240px;
+            padding: 22px 20px;
+            background-image: url('../assets/ui-for-rpg/PNG/character_panel.png');
+            background-size: 100% 100%;
+            background-repeat: no-repeat;
+            background-color: rgba(16, 8, 12, 0.9);
+            border: 1px solid #6b1f2a;
+            border-radius: 6px;
+            box-shadow: 0 6px 22px rgba(0, 0, 0, 0.7);
+            image-rendering: pixelated;
+        }
+
+        .pause-card .pc-title {
+            font-family: 'Cinzel', serif;
+            font-size: 20px;
+            font-weight: 900;
+            color: #f3e6d3;
+            margin-bottom: 14px;
+            text-shadow: 0 1px 4px #000;
+        }
+
+        .pause-card .pc-stat {
+            font-size: 14px;
+            color: #d8cdbf;
+            margin-top: 8px;
+        }
+
+        .pause-card .pc-stat b {
+            color: #f3e6d3;
+        }
+
+        .pause-lists {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            min-width: 300px;
+        }
+
+        .pause-section-title {
+            font-family: 'Cinzel', serif;
+            font-size: 14px;
+            font-weight: 900;
+            letter-spacing: 2px;
+            color: #c79aa4;
+            margin-bottom: 6px;
+        }
+
+        .pause-row {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 7px 12px;
+            margin: 0 8px 8px 0;
+            font-family: 'Cinzel', serif;
+            font-size: 14px;
+            font-weight: 700;
+            color: #f3e6d3;
+            background-image: url('../assets/ui-for-rpg/PNG/Action_panel.png');
+            background-size: 100% 100%;
+            background-repeat: no-repeat;
+            background-color: rgba(16, 8, 12, 0.88);
+            border: 1px solid #6b1f2a;
+            border-radius: 5px;
+            text-shadow: 0 1px 3px #000;
+            cursor: help;
+            image-rendering: pixelated;
+        }
+
+        .pause-row .pr-lv {
+            color: #ffd9a0;
+            font-size: 12px;
+            margin-left: 2px;
         }
     </style>
 </head>
@@ -437,6 +590,32 @@
         <button class="btn" id="chestBtn">Coletar</button>
     </div>
 
+    <div class="overlay hidden" id="pauseScreen">
+        <h1>PAUSADO</h1>
+        <div class="subtitle">Estatísticas da caçada</div>
+        <div class="pause-content">
+            <div class="pause-card">
+                <div class="pc-title" id="pauseLevel">Nv 1</div>
+                <div class="pc-stat">Abates: <b id="pauseKills">0</b></div>
+                <div class="pc-stat">Tempo: <b id="pauseTime">00:00</b></div>
+                <div class="pc-stat">Vida: <b id="pauseHp">100 / 100</b></div>
+            </div>
+            <div class="pause-lists">
+                <div class="pause-section">
+                    <div class="pause-section-title">ARMAS</div>
+                    <div id="pauseWeapons"></div>
+                </div>
+                <div class="pause-section">
+                    <div class="pause-section-title">PASSIVOS</div>
+                    <div id="pausePassives"></div>
+                </div>
+            </div>
+        </div>
+        <div class="hint">Pressione <span class="key">ENTER</span> para continuar</div>
+    </div>
+
+    <div class="tooltip" id="tooltip"></div>
+
     <script>
     (function () {
         'use strict';
@@ -476,11 +655,11 @@
         const MAX_ENEMY_RADIUS = Math.max(CONFIG.skeleton.radius, CONFIG.boss.radius);
 
         const WEAPONS = {
-            sword: { name: 'Espada', behavior: 'melee-horizontal', damage: 20, interval: 0.9, count: 1, range: 96, arcHalf: Math.PI, knockback: 30, maxLevel: 8, synergyPassive: 'pyrope', icon: '⚔️', color: '#ffcf82' },
-            axe: { name: 'Machado', behavior: 'melee-horizontal', damage: 34, interval: 1.6, count: 1, range: 72, arcHalf: Math.PI, knockback: 44, maxLevel: 8, synergyPassive: 'mechanism', icon: '🪓', color: '#ff8a72' },
-            bow: { name: 'Arco', behavior: 'nearest-projectile', damage: 12, interval: 0.9, count: 1, projectileSpeed: 380, maxLevel: 8, synergyPassive: 'feather', icon: '🏹', color: '#bfe6ff' },
-            crossbow: { name: 'Besta', behavior: 'nearest-projectile', damage: 10, interval: 1.2, count: 1, projectileSpeed: 460, pierce: true, maxLevel: 8, synergyPassive: 'amulet', icon: '🎯', color: '#7df0ff' },
-            holy_water: { name: 'Água Benta', behavior: 'random-area', damage: 10, interval: 2.0, count: 1, area: 70, duration: 3.0, maxLevel: 8, synergyPassive: 'mushroom', icon: '🧪', color: '#b78aff' }
+            sword: { name: 'Espada', desc: 'Golpeia em arco à sua volta.', behavior: 'melee-horizontal', damage: 20, interval: 0.9, count: 1, range: 96, arcHalf: Math.PI, knockback: 30, maxLevel: 8, synergyPassive: 'pyrope', icon: '⚔️', color: '#ffcf82' },
+            axe: { name: 'Machado', desc: 'Golpe pesado e lento, com grande dano e empurrão.', behavior: 'melee-horizontal', damage: 34, interval: 1.6, count: 1, range: 72, arcHalf: Math.PI, knockback: 44, maxLevel: 8, synergyPassive: 'mechanism', icon: '🪓', color: '#ff8a72' },
+            bow: { name: 'Arco', desc: 'Dispara flechas no inimigo mais próximo.', behavior: 'nearest-projectile', damage: 12, interval: 0.9, count: 1, projectileSpeed: 380, maxLevel: 8, synergyPassive: 'feather', icon: '🏹', color: '#bfe6ff' },
+            crossbow: { name: 'Besta', desc: 'Dispara virotes que atravessam vários inimigos.', behavior: 'nearest-projectile', damage: 10, interval: 1.2, count: 1, projectileSpeed: 460, pierce: true, maxLevel: 8, synergyPassive: 'amulet', icon: '🎯', color: '#7df0ff' },
+            holy_water: { name: 'Água Benta', desc: 'Derrama água benta que queima uma área por alguns segundos.', behavior: 'random-area', damage: 10, interval: 2.0, count: 1, area: 70, duration: 3.0, maxLevel: 8, synergyPassive: 'mushroom', icon: '🧪', color: '#b78aff' }
         };
 
         const EVOLVED_WEAPONS = {
@@ -492,14 +671,14 @@
         };
 
         const PASSIVES = {
-            amulet: { name: 'Amuleto', stat: 'area', amount: 0.10, maxLevel: 5, icon: '📿' },
-            pyrope: { name: 'Joia Carmesim', stat: 'might', amount: 0.10, maxLevel: 5, icon: '💎' },
-            mechanism: { name: 'Engrenagem', stat: 'cooldown', amount: 0.08, maxLevel: 5, icon: '⚙️' },
-            feather: { name: 'Pena', stat: 'speed', amount: 0.10, maxLevel: 5, icon: '🪶' },
-            meat: { name: 'Carne', stat: 'maxhp', amount: 15, maxLevel: 5, icon: '🥩' },
-            mushroom: { name: 'Cogumelo Noturno', stat: 'regen', amount: 0.5, maxLevel: 5, icon: '🍄' },
-            spirit_orb: { name: 'Orbe Espiritual', stat: 'magnet', amount: 15, maxLevel: 5, icon: '🔮' },
-            boar_ring: { name: 'Anel do Javali', stat: 'move_speed', amount: 0.06, maxLevel: 5, icon: '💍' }
+            amulet: { name: 'Amuleto', desc: 'Aumenta a área de efeito.', stat: 'area', amount: 0.10, maxLevel: 5, icon: '📿' },
+            pyrope: { name: 'Joia Carmesim', desc: 'Aumenta o dano das armas.', stat: 'might', amount: 0.10, maxLevel: 5, icon: '💎' },
+            mechanism: { name: 'Engrenagem', desc: 'Reduz o tempo de recarga das armas.', stat: 'cooldown', amount: 0.08, maxLevel: 5, icon: '⚙️' },
+            feather: { name: 'Pena', desc: 'Aumenta a velocidade dos projéteis.', stat: 'speed', amount: 0.10, maxLevel: 5, icon: '🪶' },
+            meat: { name: 'Carne', desc: 'Aumenta a vida máxima.', stat: 'maxhp', amount: 15, maxLevel: 5, icon: '🥩' },
+            mushroom: { name: 'Cogumelo Noturno', desc: 'Regenera vida aos poucos.', stat: 'regen', amount: 0.5, maxLevel: 5, icon: '🍄' },
+            spirit_orb: { name: 'Orbe Espiritual', desc: 'Atrai gemas de mais longe.', stat: 'magnet', amount: 15, maxLevel: 5, icon: '🔮' },
+            boar_ring: { name: 'Anel do Javali', desc: 'Aumenta a velocidade de movimento.', stat: 'move_speed', amount: 0.06, maxLevel: 5, icon: '💍' }
         };
 
         const canvas = document.getElementById('game');
@@ -532,6 +711,14 @@
         const goKills = document.getElementById('goKills');
         const goLevel = document.getElementById('goLevel');
         const goBest = document.getElementById('goBest');
+        const tooltip = document.getElementById('tooltip');
+        const pauseScreen = document.getElementById('pauseScreen');
+        const pauseLevel = document.getElementById('pauseLevel');
+        const pauseKills = document.getElementById('pauseKills');
+        const pauseTime = document.getElementById('pauseTime');
+        const pauseHp = document.getElementById('pauseHp');
+        const pauseWeapons = document.getElementById('pauseWeapons');
+        const pausePassives = document.getElementById('pausePassives');
 
         const ASSETS = {
             playerWalk: '../assets/swordsman-1-3-level-pixel-top-down-sprite-character/PNG/Swordsman_lvl1/With_shadow/Swordsman_lvl1_Walk_with_shadow.png',
@@ -775,6 +962,60 @@
             recomputeStats();
         }
 
+        const STAT_LABELS = {
+            area: 'área de efeito',
+            might: 'dano',
+            cooldown: 'recarga',
+            speed: 'vel. de projéteis',
+            maxhp: 'vida máxima',
+            regen: 'regeneração',
+            magnet: 'raio de coleta',
+            move_speed: 'vel. de movimento'
+        };
+
+        function passiveBonusText(c, level) {
+            if (c.stat === 'cooldown') return '-' + Math.round(c.amount * 100) + '% ' + STAT_LABELS[c.stat] + ' por nível';
+            if (c.stat === 'maxhp' || c.stat === 'magnet') return '+' + c.amount + ' ' + STAT_LABELS[c.stat] + ' por nível';
+            return '+' + Math.round(c.amount * 100) + '% ' + STAT_LABELS[c.stat] + ' por nível';
+        }
+
+        function describeWeapon(w) {
+            const c = WEAPONS[w.id];
+            const name = w.evolvedName || c.name;
+            let html = '<div class="tip-title">' + c.icon + ' ' + name + '</div>';
+            html += '<div class="tip-level">Nível ' + w.level + ' / ' + w.maxLevel + '</div>';
+            html += '<div class="tip-desc">' + c.desc + '</div>';
+            const lines = [];
+            lines.push('Dano: ' + Math.round(w.damage));
+            lines.push('Recarga: ' + w.interval.toFixed(2) + 's');
+            if (w.range) lines.push('Alcance: ' + Math.round(w.range));
+            if (w.area) lines.push('Área: ' + Math.round(w.area));
+            if (w.duration) lines.push('Duração: ' + w.duration.toFixed(1) + 's');
+            if (c.behavior === 'nearest-projectile' && w.count > 1) lines.push('Projéteis: ' + w.count);
+            else if (c.behavior === 'random-area' && w.count > 1) lines.push('Poças: ' + w.count);
+            if (w.pierce) lines.push('Atravessa inimigos');
+            html += '<div class="tip-stats">' + lines.join('<br>') + '</div>';
+            if (w.evolved) {
+                html += '<div class="tip-evo">✦ Evoluída</div>';
+            } else if (c.synergyPassive) {
+                html += '<div class="tip-evo">Evolui no nv ' + w.maxLevel + ' com ' + PASSIVES[c.synergyPassive].name + '</div>';
+            }
+            return html;
+        }
+
+        function describePassive(p) {
+            const c = PASSIVES[p.id];
+            let html = '<div class="tip-title">' + c.icon + ' ' + c.name + '</div>';
+            html += '<div class="tip-level">Nível ' + p.level + ' / ' + c.maxLevel + '</div>';
+            html += '<div class="tip-desc">' + c.desc + '</div>';
+            let total;
+            if (c.stat === 'cooldown') total = '-' + Math.round(c.amount * p.level * 100) + '%';
+            else if (c.stat === 'maxhp' || c.stat === 'magnet') total = '+' + (c.amount * p.level);
+            else total = '+' + Math.round(c.amount * p.level * 100) + '%';
+            html += '<div class="tip-stats">' + passiveBonusText(c, p.level) + '<br>Total atual: ' + total + '</div>';
+            return html;
+        }
+
         function recomputeStats() {
             const s = { area: 1, might: 1, cooldown: 1, speed: 1, maxhp: 0, regen: 0, magnet: 0, move_speed: 1 };
             for (const p of player.passives) {
@@ -838,6 +1079,7 @@
             gameoverScreen.classList.add('hidden');
             levelupScreen.classList.add('hidden');
             chestScreen.classList.add('hidden');
+            pauseScreen.classList.add('hidden');
             if (s === 'menu') startScreen.classList.remove('hidden');
             if (s === 'gameover') {
                 goTime.textContent = formatTime(game.time);
@@ -848,6 +1090,7 @@
             }
             if (s === 'levelup') levelupScreen.classList.remove('hidden');
             if (s === 'chest') chestScreen.classList.remove('hidden');
+            if (s === 'paused') pauseScreen.classList.remove('hidden');
         }
 
         function startGame() {
@@ -904,6 +1147,30 @@
             }
         }
 
+        function showTooltip(html, clientX, clientY) {
+            tooltip.innerHTML = html;
+            tooltip.classList.add('visible');
+            const pad = 16;
+            const tw = tooltip.offsetWidth || 220;
+            const th = tooltip.offsetHeight || 140;
+            let x = clientX + pad;
+            let y = clientY + pad;
+            if (x + tw > window.innerWidth - 8) x = clientX - tw - pad;
+            if (y + th > window.innerHeight - 8) y = clientY - th - pad;
+            tooltip.style.left = Math.max(8, x) + 'px';
+            tooltip.style.top = Math.max(8, y) + 'px';
+        }
+
+        function hideTooltip() {
+            tooltip.classList.remove('visible');
+        }
+
+        function bindTooltip(el, getHtml) {
+            el.addEventListener('mouseenter', function (e) { showTooltip(getHtml(), e.clientX, e.clientY); });
+            el.addEventListener('mousemove', function (e) { showTooltip(getHtml(), e.clientX, e.clientY); });
+            el.addEventListener('mouseleave', hideTooltip);
+        }
+
         function updateWeaponsRow() {
             weaponsRow.innerHTML = '';
             for (const w of player.weapons) {
@@ -911,7 +1178,7 @@
                 const chip = document.createElement('span');
                 chip.className = 'weapon-chip';
                 chip.textContent = (w.evolved ? '✨' : '') + c.icon + ' ' + w.level;
-                chip.title = w.evolvedName || c.name;
+                bindTooltip(chip, function () { return describeWeapon(w); });
                 weaponsRow.appendChild(chip);
             }
         }
@@ -923,7 +1190,44 @@
                 const chip = document.createElement('span');
                 chip.className = 'passive-chip';
                 chip.textContent = c.icon + ' ' + p.level;
+                bindTooltip(chip, function () { return describePassive(p); });
                 passivesRow.appendChild(chip);
+            }
+        }
+
+        function renderPauseScreen() {
+            pauseLevel.textContent = 'Nv ' + player.level;
+            pauseKills.textContent = String(game.kills);
+            pauseTime.textContent = formatTime(game.time);
+            pauseHp.textContent = Math.ceil(player.hp) + ' / ' + player.maxHp;
+            pauseWeapons.innerHTML = '';
+            for (const w of player.weapons) {
+                const c = WEAPONS[w.id];
+                const name = w.evolvedName || c.name;
+                const row = document.createElement('span');
+                row.className = 'pause-row';
+                row.innerHTML = (w.evolved ? '✨' : '') + c.icon + ' ' + name + '<span class="pr-lv">Nv ' + w.level + '</span>';
+                bindTooltip(row, function () { return describeWeapon(w); });
+                pauseWeapons.appendChild(row);
+            }
+            pausePassives.innerHTML = '';
+            for (const p of player.passives) {
+                const c = PASSIVES[p.id];
+                const row = document.createElement('span');
+                row.className = 'pause-row';
+                row.innerHTML = c.icon + ' ' + c.name + '<span class="pr-lv">Nv ' + p.level + '</span>';
+                bindTooltip(row, function () { return describePassive(p); });
+                pausePassives.appendChild(row);
+            }
+        }
+
+        function togglePause() {
+            if (game.status === 'playing') {
+                renderPauseScreen();
+                setStatus('paused');
+                for (const k in keys) keys[k] = false;
+            } else if (game.status === 'paused') {
+                setStatus('playing');
             }
         }
 
@@ -939,6 +1243,7 @@
             else if (game.status === 'gameover' && k === 'enter') startGame();
             else if (game.status === 'levelup' && (k === '1' || k === '2' || k === '3')) chooseUpgrade(parseInt(k, 10) - 1);
             else if (game.status === 'chest' && (k === 'enter' || k === ' ')) closeChest();
+            else if ((game.status === 'playing' || game.status === 'paused') && k === 'enter') togglePause();
         }
 
         function onKeyUp(e) {
@@ -1238,25 +1543,28 @@
             opts.forEach(function (opt, i) {
                 const el = document.createElement('div');
                 el.className = 'upgrade-card';
-                let icon, title, desc;
+                let icon, title, desc, prog = '';
                 if (opt.kind === 'heal') {
                     icon = '❤️';
                     title = 'Restaurar Vida';
-                    desc = '+' + CONFIG.healAmount + ' de vida';
+                    desc = 'Recupera parte da sua vida.';
+                    prog = '+' + CONFIG.healAmount + ' de vida';
                 } else if (opt.kind === 'weapon') {
                     const c = WEAPONS[opt.id];
                     const w = player.weapons.find(function (x) { return x.id === opt.id; });
                     icon = c.icon;
                     title = c.name;
-                    desc = w ? ('Nível ' + w.level + ' → ' + (w.level + 1)) : 'NOVA ARMA';
+                    desc = c.desc;
+                    prog = w ? ('Nível ' + w.level + ' → ' + (w.level + 1)) : 'NOVA ARMA';
                 } else {
                     const c = PASSIVES[opt.id];
                     const p = player.passives.find(function (x) { return x.id === opt.id; });
                     icon = c.icon;
                     title = c.name;
-                    desc = p ? ('Nível ' + p.level + ' → ' + (p.level + 1)) : 'NOVO PASSIVO';
+                    desc = c.desc + '<br>' + passiveBonusText(c, 1);
+                    prog = p ? ('Nível ' + p.level + ' → ' + (p.level + 1)) : 'NOVO PASSIVO';
                 }
-                el.innerHTML = '<div class="uc-icon">' + icon + '</div><div class="uc-title">' + title + '</div><div class="uc-desc">' + desc + '</div>';
+                el.innerHTML = '<div class="uc-icon">' + icon + '</div><div class="uc-title">' + title + '</div><div class="uc-desc">' + desc + '</div><div class="uc-prog">' + prog + '</div>';
                 el.addEventListener('click', function () { chooseUpgrade(i); });
                 upgradeCards.appendChild(el);
             });
@@ -1544,15 +1852,18 @@
                 el.className = 'upgrade-card reveal-card';
                 el.style.borderColor = '#c98a5a';
                 el.style.boxShadow = '0 0 26px rgba(220, 150, 60, 0.6)';
-                el.innerHTML = '<div class="uc-icon">' + evoInfo.icon + '</div><div class="uc-title">' + evoInfo.newName + '</div><div class="uc-desc">EVOLUÇÃO! (' + evoInfo.oldName + ' → ' + evoInfo.newName + ')</div>';
+                const base = WEAPONS[evoInfo.id];
+                el.innerHTML = '<div class="uc-icon">' + evoInfo.icon + '</div><div class="uc-title">' + evoInfo.newName + '</div><div class="uc-desc">' + base.desc + '</div><div class="uc-prog">EVOLUÇÃO! (' + evoInfo.oldName + ' → ' + evoInfo.newName + ')</div>';
                 chestCards.appendChild(el);
             }
             infos.forEach(function (info, i) {
                 const el = document.createElement('div');
                 el.className = 'upgrade-card reveal-card';
                 el.style.animationDelay = ((evoInfo ? 1 : 0) + i * 0.25) + 's';
-                const desc = info.isNew ? 'NOVA ARMA' : ('Nível ' + info.level + ' → ' + (info.level + 1));
-                el.innerHTML = '<div class="uc-icon">' + info.icon + '</div><div class="uc-title">' + info.name + '</div><div class="uc-desc">' + desc + '</div>';
+                const c = WEAPONS[info.id];
+                const desc = c.desc;
+                const prog = info.isNew ? 'NOVA ARMA' : ('Nível ' + info.level + ' → ' + (info.level + 1));
+                el.innerHTML = '<div class="uc-icon">' + info.icon + '</div><div class="uc-title">' + info.name + '</div><div class="uc-desc">' + desc + '</div><div class="uc-prog">' + prog + '</div>';
                 chestCards.appendChild(el);
             });
         }


### PR DESCRIPTION
## 🎨 Planejamento das melhorias gráficas (sem alterar mecânica)

Documento de planejamento `blood_and_silver/TASKS/TASK_010.md` para a sprint 2, focada em corrigir o uso dos sprites e construir o cenário.

### Problemas identificados
- O **inimigo** atual usa `Animation3.png`, que é um **objeto de cenário (árvore/toco)** — não uma criatura. O pacote `skeleton-top-down-pixel-art` não tem esqueleto andando.
- O **chão** é procedural (cor + grade), sem uso dos tiles.
- **Não há objetos decorativos** espalhados.

### Decisões planejadas
1. **Inimigos → vampiros** (`Vampires1` Walk/Idle, 64×64, 4 direções `front/back/left/right`); chefe = `Vampires3` escalado.
2. **Chão → tiles** `Ground_rocks.png` (tile em (32,32)), renderizado via `ctx.createPattern` (O(1)).
3. **Água → lagoas decorativas** com `Water_coasts.png` (água aberta em (384,224)).
4. **Objetos → espalhados** com PRNG semeado (mundo determinístico), não-colidíveis.

### Investigação (subagentes + verificação por pixels)
- Mapeamento exato dos tiles por comparação de pixels (diff=0).
- Descoberta de que `PNG/` e `Tiled_files/` têm layouts **diferentes** (o `.tmx` referencia `Tiled_files/`), então os índices do `.tmx` não se aplicam diretamente.
- Recomendação de usar `Objects_separately/` (objetos nomeados e recortados) em vez de `Objects.png`.

> Apenas documentação/planejamento — nenhuma execução de código nesta PR.